### PR TITLE
Migrate to FDO 23.08 and add /run/udev:ro permission to manifest.

### DIFF
--- a/io.github.hmlendea.geforcenow-electron.yaml
+++ b/io.github.hmlendea.geforcenow-electron.yaml
@@ -1,10 +1,10 @@
 app-id: io.github.hmlendea.geforcenow-electron
 branch: stable
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 separate-locales: false
 command: start-geforcenow-electron
 
@@ -16,6 +16,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=/run/udev:ro
 
 modules:
   - name: geforcenow-electron


### PR DESCRIPTION
Hi there. This software came up on reddit, and I noticed that people using it were having trouble with gamepad detection because Electron needs to see `/run/udev` to detect and use gamepads. I saw [in this issue](https://github.com/hmlendea/gfn-electron/issues/105) that you didn't know how to add this permission to the manifest, so I just went ahead and took care of it for you. The workarounds should no longer be needed by anyone using this.

I went ahead and migrated to the 23.08 runtime while I was at it, too. This has newer components which should result in improved performance.