### PR TITLE
Use freedesktop-sdk 25.08 runtime

### DIFF
--- a/io.github.hmlendea.geforcenow-electron.yaml
+++ b/io.github.hmlendea.geforcenow-electron.yaml
@@ -1,5 +1,4 @@
 app-id: io.github.hmlendea.geforcenow-electron
-branch: stable
 runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk

--- a/io.github.hmlendea.geforcenow-electron.yaml
+++ b/io.github.hmlendea.geforcenow-electron.yaml
@@ -1,10 +1,10 @@
 app-id: io.github.hmlendea.geforcenow-electron
 branch: stable
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 separate-locales: false
 command: start-geforcenow-electron
 


### PR DESCRIPTION
23.08 runtime is EOL and shows ugly warning for all users

Fixes https://github.com/flathub/io.github.hmlendea.geforcenow-electron/issues/55